### PR TITLE
Improvements to ztf_archive + CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+os:
+  - linux
+
+python:
+  - 3.7
+
+install:
+  - python setup.py install
+
+script:
+  - pytest

--- a/broker/ztf_archive/__init__.py
+++ b/broker/ztf_archive/__init__.py
@@ -7,8 +7,9 @@ the 24hr ZTF alerts archive.
 
 from ._download_data import download_data_date
 from ._download_data import download_recent_data
-from ._download_data import get_number_local_alerts
-from ._download_data import get_number_local_releases
+from ._download_data import get_remote_release_list
+from ._download_data import get_local_release_list
+from ._download_data import get_local_alert_list
 from ._parse_data import get_alert_data
 from ._parse_data import iter_alerts
 from ._parse_data import plot_stamps

--- a/broker/ztf_archive/__init__.py
+++ b/broker/ztf_archive/__init__.py
@@ -5,7 +5,8 @@
 the 24hr ZTF alerts archive.
 """
 
-from ._download_data import download_data
+from ._download_data import download_data_date
+from ._download_data import download_recent_data
 from ._download_data import get_number_local_alerts
 from ._download_data import get_number_local_releases
 from ._parse_data import get_alert_data

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -7,7 +7,7 @@ import tarfile
 from glob import glob
 from os import makedirs
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryFile
 
 import numpy as np
 import requests
@@ -103,12 +103,13 @@ def _download_alerts_file(url, out_path):
         unit_scale=True)
 
     # write data to file
-    with NamedTemporaryFile() as ofile:
+    with TemporaryFile() as ofile:
         for data in data_iterable:
             ofile.write(data)
 
         tqdm.write('Unzipping alert data...')
-        with tarfile.open(ofile.name, "r:gz") as data:
+        ofile.seek(0)
+        with tarfile.open(fileobj=ofile, mode="r:gz") as data:
             data.extractall(out_dir)
 
 

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -58,7 +58,10 @@ def get_local_release_list():
         A list of downloaded files from the ZTF Alerts Archive
     """
 
-    with open(ALERT_LOG) as ofile:
+    if not ALERT_LOG.exists():
+        return []
+
+    with open(ALERT_LOG, 'a') as ofile:
         return [line.strip() for line in ofile]
 
 

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -103,11 +103,30 @@ def _download_alerts_file(url, out_path):
             data.extractall(out_dir)
 
 
-def download_data(max_downloads=1):
+def download_data_date(year, month, day):
+    """Download ZTF alerts for a given date
+
+    Does not skip releases that are were previously downloaded.
+
+    Args:
+        year  (int): The year of the data to download
+        month (int): The month of the data to download
+        day   (int): The day of the data to download
+    """
+
+    file_name = f'ztf_public_{year}{month:02d}{day:02d}.tar.gz'
+    tqdm.write(f'Downloading {file_name}')
+
+    out_path = DATA_DIR / file_name
+    url = requests.compat.urljoin(ZTF_URL, file_name)
+    _download_alerts_file(url, out_path)
+
+
+def download_recent_data(max_downloads=1):
     """Download recent alert data from the ZTF alerts archive
 
-    Automatically skip published alerts that are empty. More recent releases
-    are downloaded first. Skip releases that are already downloaded.
+    More recent releases are downloaded first. Skip releases that are already
+    downloaded.
 
     Args:
         max_downloads (int): Number of daily releases to download (default = 1)
@@ -116,7 +135,7 @@ def download_data(max_downloads=1):
     file_list = _get_remote_file_list()
     num_downloads = min(max_downloads, len(file_list))
     for i, file_name in enumerate(file_list):
-        if i + 1 > max_downloads:
+        if i >= max_downloads:
             break
 
         # Skip download if data was already downloaded

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -132,14 +132,16 @@ def download_data_date(year, month, day):
     _download_alerts_file(file_name, out_path)
 
 
-def download_recent_data(max_downloads=1):
+def download_recent_data(max_downloads=1, stop_on_exist=False):
     """Download recent alert data from the ZTF alerts archive
 
-    More recent releases are downloaded first. Skip releases that are already
-    downloaded.
+    Data is downloaded in reverse chronological order. Skip releases that are
+    already downloaded.
 
     Args:
-        max_downloads (int): Number of daily releases to download (default = 1)
+        max_downloads  (int): Number of daily releases to download (default: 1)
+        stop_on_exist (bool): Exit when encountering an alert that is already
+                               downloaded (Default: False)
     """
 
     file_list = get_remote_release_list()
@@ -152,11 +154,14 @@ def download_recent_data(max_downloads=1):
         if file_name in get_local_release_list():
             tqdm.write(
                 f'Already Downloaded ({i + 1}/{num_downloads}): {file_name}')
-            continue
+
+            if stop_on_exist:
+                return
+
+            else:
+                continue
 
         out_path = DATA_DIR / file_name
         tqdm.write(f'Downloading ({i + 1}/{num_downloads}): {file_name}')
 
         _download_alerts_file(file_name, out_path)
-        with open(ALERT_LOG, 'a') as ofile:
-            ofile.write(file_name)

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -77,8 +77,8 @@ def _download_alerts_file(file_name, out_path):
     """Download a file from the ZTF Alerts Archive
 
     Args:
-        url      (str): URL of the file to download
-        out_path (str): The path where the downloaded file should be written
+        file_name (str): Name of the file to download
+        out_path  (str): The path where the downloaded file should be written
     """
 
     out_dir = Path(out_path).parent
@@ -158,10 +158,8 @@ def download_recent_data(max_downloads=1, stop_on_exist=False):
             if stop_on_exist:
                 return
 
-            else:
-                continue
+            continue
 
         out_path = DATA_DIR / file_name
         tqdm.write(f'Downloading ({i + 1}/{num_downloads}): {file_name}')
-
         _download_alerts_file(file_name, out_path)

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -57,15 +57,18 @@ def get_alert_data(candid, raw=False):
         raise ValueError(f'Data for candid "{candid}" not locally available.')
 
 
-def iter_alerts(num_alerts=1, raw=False):
+def iter_alerts(num_alerts=None, raw=False):
     """Iterate over all locally available alert data
 
+    If ``num_alerts`` is not specified, yield individual alerts. Otherwise,
+    yield a list of alerts with length ``num_alerts``.
+
     Args:
-        num_alerts (int): Maximum number of alerts to yield at a time
-        raw       (bool): Optionally return file data as bytes (Default: False)
+        num_alerts (int): Maximum number of alerts to yield at a time (optional)
+        raw       (bool): Return file data as bytes (Default: False)
 
     Yields:
-        A list of dictionaries with ZTF alert data
+        A list of dictionaries or bytes representing ZTF alert data
     """
 
     err_msg = 'num_alerts argument must be an int >= 1'
@@ -81,6 +84,14 @@ def iter_alerts(num_alerts=1, raw=False):
         raise RuntimeError(
             "No local alert data found. Please run 'download_data' first.")
 
+    # Return individual alerts
+    if num_alerts is None:
+        for file_path in file_list:
+            yield _parse_alert_file(file_path, raw)
+
+        return
+
+    # Return alerts as list
     alerts_list = []
     for file_path in file_list:
         alerts_list.append(_parse_alert_file(file_path, raw))

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -54,7 +54,8 @@ def get_alert_data(candid, raw=False):
         return _parse_alert_file(path, raw)
 
     except FileNotFoundError:
-        raise ValueError(f'Data for candid "{candid}" not locally available.')
+        raise ValueError(
+            f'Data for candid "{candid}" not locally available (at {path}).')
 
 
 def iter_alerts(num_alerts=None, raw=False):

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -73,10 +73,7 @@ def iter_alerts(num_alerts=None, raw=False):
     """
 
     err_msg = 'num_alerts argument must be an int >= 1'
-    if not isinstance(num_alerts, int):
-        raise TypeError(err_msg)
-
-    elif num_alerts <= 0:
+    if num_alerts and num_alerts <= 0:
         raise ValueError(err_msg)
 
     path_pattern = os.path.join(DATA_DIR, '*.avro')

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -72,11 +72,11 @@ def iter_alerts(num_alerts=None, raw=False):
     """
 
     err_msg = 'num_alerts argument must be an int >= 1'
-    if num_alerts <= 0:
-        raise ValueError(err_msg)
-
-    elif not isinstance(num_alerts, int):
+    if not isinstance(num_alerts, int):
         raise TypeError(err_msg)
+
+    elif num_alerts <= 0:
+        raise ValueError(err_msg)
 
     path_pattern = os.path.join(DATA_DIR, '*.avro')
     file_list = glob(path_pattern)

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -38,11 +38,12 @@ def _parse_alert_file(path, raw=False):
             return next(fastavro.reader(f))
 
 
-def get_alert_data(candid):
+def get_alert_data(candid, raw=False):
     """Return the contents of an avro file published by ZTF
 
     Args:
         candid (int): Unique ZTF identifier for the subtraction candidate
+        raw   (bool): Optionally return the file data as bytes (Default: False)
 
     Returns:
         The file contents as a dictionary
@@ -50,7 +51,7 @@ def get_alert_data(candid):
 
     path = os.path.join(DATA_DIR, f'{candid}.avro')
     try:
-        return _parse_alert_file(path)
+        return _parse_alert_file(path, raw)
 
     except FileNotFoundError:
         raise ValueError(f'Data for candid "{candid}" not locally available.')

--- a/docs/source/module_docs/api_reference.rst
+++ b/docs/source/module_docs/api_reference.rst
@@ -24,7 +24,8 @@ broker.ztf_archive
 
 .. autosummary::
 
-    download_data
+    download_data_date
+    download_recent_data
     get_number_local_alerts
     get_number_local_releases
     get_alert_data

--- a/docs/source/module_docs/api_reference.rst
+++ b/docs/source/module_docs/api_reference.rst
@@ -26,8 +26,9 @@ broker.ztf_archive
 
     download_data_date
     download_recent_data
-    get_number_local_alerts
-    get_number_local_releases
+    get_remote_release_list
+    get_local_release_list
+    get_local_alert_list
     get_alert_data
     iter_alerts
     plot_stamps

--- a/docs/source/module_docs/ztf_archive.rst
+++ b/docs/source/module_docs/ztf_archive.rst
@@ -5,9 +5,13 @@ ztf_archive
 
 .. autofunction:: download_data_date
 
-.. autofunction:: get_number_local_alerts
+.. autofunction:: download_recent_data
 
-.. autofunction:: get_number_local_releases
+.. autofunction:: get_remote_release_list
+
+.. autofunction:: get_local_release_list
+
+.. autofunction:: get_local_alert_list
 
 .. autofunction:: get_alert_data
 

--- a/docs/source/module_docs/ztf_archive.rst
+++ b/docs/source/module_docs/ztf_archive.rst
@@ -3,7 +3,7 @@ ztf_archive
 
 .. py:currentmodule:: broker.ztf_archive
 
-.. autofunction:: download_data
+.. autofunction:: download_data_date
 
 .. autofunction:: get_number_local_alerts
 

--- a/docs/source/quick_start/ztf_archive.rst
+++ b/docs/source/quick_start/ztf_archive.rst
@@ -5,8 +5,14 @@ All ZTF alerts are submitted at the end of the day to the `ZTF public alerts
 archive`_. The ``ztf_archive`` module is capable of automatically downloading,
 parsing, and plotting alert data that has been submitted to the public archive.
 Alert data can only be downloaded in groups of daily data releases (i.e. you
-cannot download individual alerts). The following code snippet demonstrates
+cannot download individual alerts). The following code snippets demonstrates
 how to download and access data from the ZTF archive.
+
+Downloading From the Archive
+----------------------------
+
+Daily data releases can be downloaded from the ZTF archive individually or
+iteratively in reverse chronological order.
 
 .. code:: python
 
@@ -18,7 +24,34 @@ how to download and access data from the ZTF archive.
    # Download data from the ZTF archive for a given day.
    ztfa.download_data_date(year=2018, month=6, day=26)
 
-   # Get a list of downloaded files from the archive
+   # Download the most recent day of available data
+   ztfa.download_recent_data()
+
+Although it is not recommended to download the entire alerts archive to your
+local machine, it is an educational thought exercise to see a few different
+cases of how this would work.
+
+.. code:: python
+
+   # Download all of the alerts and skip ones that have already been downloaded
+   ztfa.download_recent_data(max_downloads=float('inf'))
+
+   # Download all of the alerts while overwriting any existing data
+   ztfa.download_recent_data(max_downloads=float('inf'))
+
+   # Exit the function call once files are encountered that have already
+   # been downloaded.
+   ztfa.download_recent_data(max_downloads=float('inf'), stop_on_exist=True)
+
+Accessing Local Alerts
+----------------------
+
+The ``ztf_archive`` module also provides functions for accessing and
+visualizing alert data.
+
+.. code:: python
+
+   # Get a list of files downloaded from the archive
    print(ztfa.get_local_release_list())
 
    # Retrieve the IDs for all alerts downloaded to your local machine
@@ -33,11 +66,19 @@ how to download and access data from the ZTF archive.
    fig = ztfa.plot_stamps(alert_data)
    fig.show()
 
-   # Alternatively, you can iterate through alert data, 5 alerts at a time.
-   # The ztfa.iter_alerts function yields a list of alert packets
-   for alert_list in ztfa.iter_alerts(5):
-       alert_ids = [alert['candid'] for alert in alert_list]
-       print(alert_ids)
+In addition to acceding individual alerts by their ID value, you can iterate
+over the entire set of downloaded alert data.
+
+.. code:: python
+
+   # Iterate over alerts one at a time
+   for alert_list in ztfa.iter_alerts():
+       # Some redundant task
+       break
+
+   # Or iterate over multiple alerts at once
+   for alert_1, alert_2 in ztfa.iter_alerts(2):
+       # Some other redundant task
        break
 
 .. _ZTF public alerts archive: https://ztf.uw.edu/alerts/public/

--- a/docs/source/quick_start/ztf_archive.rst
+++ b/docs/source/quick_start/ztf_archive.rst
@@ -12,30 +12,32 @@ how to download and access data from the ZTF archive.
 
    from broker import ztf_archive as ztfa
 
-   # Download recent data from the ZTF archive.
-   # Note: Daily releases can be as large as several Gb
-   ztfa.download_data()
+   # Get a list of files available on the ZTF Alerts Archive
+   print(ztfa.get_remote_release_list())
 
-   # Retrieve the number of daily releases that are locally available
-   print(ztfa.get_number_local_releases())
+   # Download data from the ZTF archive for a given day.
+   ztfa.download_data_date(year=2018, month=6, day=26)
 
-   # Retrieve the number of alerts that have been downloaded
-   # from all combined daily releases.
-   print(ztfa.get_number_local_alerts())
+   # Get a list of downloaded files from the archive
+   print(ztfa.get_local_release_list())
 
-   # Iterate through alert data, 5 alerts at a time.
+   # Retrieve the IDs for all alerts downloaded to your local machine
+   alert_ids = ztfa.get_local_alert_list()
+   print(alert_ids)
+
+   # Get data for a specific alert
+   demo_id = alert_ids[0]
+   alert_data = ztfa.get_alert_data(demo_id)
+
+   # Plot image stamps used to generate the alert data
+   fig = ztfa.plot_stamps(alert_data)
+   fig.show()
+
+   # Alternatively, you can iterate through alert data, 5 alerts at a time.
    # The ztfa.iter_alerts function yields a list of alert packets
    for alert_list in ztfa.iter_alerts(5):
        alert_ids = [alert['candid'] for alert in alert_list]
        print(alert_ids)
        break
-
-   # Alternatively, you can also get data for a specific alert id
-   alert_data = ztfa.get_alert_data(alert_id[0])
-   print(alert_data)
-
-   # Plot image stamps used to generate the alert data
-   fig = plot_stamps(alert_data)
-   fig.show()
 
 .. _ZTF public alerts archive: https://ztf.uw.edu/alerts/public/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ google-cloud-logging
 google-cloud-storage
 google-cloud-error-reporting
 google-resumable-media
+lxml
 matplotlib
 numpy
 pandas>=0.24.2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setup(name='pitt_broker',
-      version='0.0.1',
+      version='0.0.2',
       packages=find_packages(),
       keywords='LSST ZTF broker',
       description='A cloud based data broker for LSST and ZTF',

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""This file provides tests for the ``broker.ztf_archive`` module."""
+
+from unittest import TestCase
+
+from broker import ztf_archive as ztfa
+
+
+class DataAccess(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Download ZTF data for June 12th 2018"""
+
+        ztfa.download_data_date(2018, 6, 12)
+
+    def test_get_number_local_releases(self):
+        """Tests for ``ztf_archive.get_number_local_releases``"""
+
+        self.assertEqual(ztfa.get_number_local_releases(), 1)
+
+    def test_get_number_local_alerts(self):
+        """Tests for ``ztf_archive.get_number_local_alerts``"""
+
+        self.assertEqual(ztfa.get_number_local_alerts(), 1)
+
+    def test_format_iter_alerts(self):
+        """Tests for ``ztf_archive.iter_alerts``"""
+
+        for alert_list in ztfa.iter_alerts(1):
+            self.assertIsInstance(alert_list, list)
+            self.assertIsInstance(alert_list[0], dict)
+            break
+
+        for alert_list in ztfa.iter_alerts(10):
+            self.assertEqual(len(alert_list), 10)
+            break
+

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -17,14 +17,16 @@ class DataDownload(TestCase):
     def setUpClass(cls):
         """Download ZTF data for June 12th 2018"""
 
-        # Ignore existing local alert data
+        # Ignore existing local data by creating a temporary data directory
         cls._temp_dir = TemporaryDirectory()
-        ztfa._download_data.DATA_DIR = Path(cls._temp_dir.name)
+        temp_dir_path = Path(cls._temp_dir.name)
+        ztfa._download_data.DATA_DIR = temp_dir_path
+        ztfa._download_data.ALERT_LOG = temp_dir_path / 'alert_log.txt'
 
         try:
             # Use the 23,553 alerts generated on 06/26/2018 for testing
             cls.number_alerts = 23553
-            cls.file_name = 'ztf_public_20180626.avro'
+            cls.file_name = 'ztf_public_20180626.tar.gz'
             ztfa.download_data_date(2018, 6, 26)
 
         except:

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -3,6 +3,8 @@
 
 """This file provides tests for the ``broker.ztf_archive`` module."""
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from broker import ztf_archive as ztfa
@@ -14,7 +16,23 @@ class DataAccess(TestCase):
     def setUpClass(cls):
         """Download ZTF data for June 12th 2018"""
 
-        ztfa.download_data_date(2018, 6, 12)
+        # Ignore existing local alert data
+        cls._temp_dir = TemporaryDirectory()
+        ztfa._download_data.DATA_DIR = Path(cls._temp_dir.name)
+
+        try:
+            # Use the 23,553 alerts generated on 06/26/2018 for testing
+            cls.number_alerts = 23553
+            ztfa.download_data_date(2018, 6, 26)
+
+        except:
+            cls._temp_dir.cleanup()
+            raise
+
+    def tearDownClass(self):
+        """Delete temporary files"""
+
+        self._temp_dir.cleanup()
 
     def test_get_number_local_releases(self):
         """Tests for ``ztf_archive.get_number_local_releases``"""
@@ -24,17 +42,14 @@ class DataAccess(TestCase):
     def test_get_number_local_alerts(self):
         """Tests for ``ztf_archive.get_number_local_alerts``"""
 
-        self.assertEqual(ztfa.get_number_local_alerts(), 1)
+        self.assertEqual(ztfa.get_number_local_alerts(), self.number_alerts)
 
     def test_format_iter_alerts(self):
         """Tests for ``ztf_archive.iter_alerts``"""
 
-        for alert_list in ztfa.iter_alerts(1):
-            self.assertIsInstance(alert_list, list)
-            self.assertIsInstance(alert_list[0], dict)
-            break
+        alert_list = next(ztfa.iter_alerts(1))
+        self.assertIsInstance(alert_list, list)
+        self.assertIsInstance(alert_list[0], dict)
 
-        for alert_list in ztfa.iter_alerts(10):
-            self.assertEqual(len(alert_list), 10)
-            break
-
+        alert_list = ztfa.iter_alerts(10)
+        self.assertEqual(len(alert_list), 10)

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -62,6 +62,9 @@ class DataDownload(TestCase):
     def test_iter_alerts(self):
         """Test ``iter_alerts`` returns an appropriately sized list of dicts"""
 
+        alert = next(ztfa.iter_alerts(1))
+        self.assertIsInstance(alert, dict)
+
         alert_list = next(ztfa.iter_alerts(1))
         self.assertIsInstance(alert_list, list)
         self.assertIsInstance(alert_list[0], dict)


### PR DESCRIPTION
This PR adds tests for the `ztf_archive` module and introduces a few bug fixes. It also replaces a few functions to improve usability.

Modified Functions:
  - `get_num_local_alerts` ->  `get_local_alert_list`
  - `get_num_local_releases` -> `get_local_alert_list`

New Functions:
  - `get_remote_release_list`
  - `download_data_date`